### PR TITLE
Update .npmignore file for windows.cc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 build
 .github
 node_modules
-src
+src/*.ts
 typings_patches
 .gitignore
 .npmignore


### PR DESCRIPTION
Update .npmignore file to keep windows.cc in the final publish by only removing the .ts files in src