### PR TITLE
feat: update version of package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/deviceid",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/deviceid",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.2.0",


### PR DESCRIPTION

## Implementation
I found a version difference between packeage.json and package-lock.json.

I fixed version of `@vscode/deviceid` in package-lock.json


## Related PR

https://github.com/microsoft/vscode-deviceid/pull/18