### PR TITLE
Add support for FreeBSD

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@
 if (
 	process.platform !== "win32" &&
 	process.platform !== "darwin" &&
-	process.platform !== "linux"
+	process.platform !== "linux" &&
+	process.platform !== "freebsd"
 ) {
 	throw new Error("Unsupported platform");
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -21,7 +21,7 @@ function getDirectory(): string {
 
 	if (process.platform === "darwin") {
 		folder = path.join(process.env.HOME, "Library", "Application Support");
-	} else if (process.platform === "linux") {
+	} else if (process.platform === "linux" || process.platform === "freebsd") {
 		folder =
 			process.env.XDG_CACHE_HOME ?? path.join(process.env.HOME, ".cache");
 	} else {


### PR DESCRIPTION
This PR contains a set of changes necessary for supporting FreeBSD.

Test Result:

``` shell
$ npm install
$ npm run build
$ node -p "require('./dist/index').getDeviceId()"
Promise { 'b2885215-d3e8-44d4-ba12-21a9a888f79b' }
```

I would much appreciate it if this PR is considered for inclusion for future releases.