### PR TITLE
Strip leading UTF-8 BOM from device ID on read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/deviceid",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/deviceid",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/deviceid",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A module for Visual Studio Code to generate a unique device ID",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -42,7 +42,12 @@ export async function getDeviceId(): Promise<string | undefined> {
 		if (!(await exists(getDeviceIdFilePath()))) {
 			return undefined;
 		} else {
-			return fs.readFile(getDeviceIdFilePath(), "utf8");
+			const content = await fs.readFile(getDeviceIdFilePath(), "utf8");
+			// Strip a leading UTF-8 BOM (U+FEFF) if present. Node's "utf8"
+			// decoding does not strip it, and a stray BOM in the device ID
+			// breaks downstream consumers that put the value in HTTP headers
+			// (see issue #34).
+			return content.replace(/^\uFEFF/, "");
 		}
 	}
 }


### PR DESCRIPTION
On macOS/Linux, getDeviceId() reads the device ID file with Node's utf8 decoding, which does not strip a leading UTF-8 BOM (U+FEFF). When the file was written with a BOM by another tool sharing the same path, the returned string starts with U+FEFF and breaks consumers that use it in HTTP headers (e.g. Electron's Request rejects header values containing chars > 255), causing 100% request failure in Copilot Chat.

Defensively strip a single leading BOM after reading.

Fixes #34