### PR TITLE
Update pipelines to use MicroBuild.1ES.Official.Publish.yml

### DIFF
--- a/azure-pipelines/azure-pipeline.yml
+++ b/azure-pipelines/azure-pipeline.yml
@@ -27,7 +27,7 @@ extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   # For non-production pipelines, use "Unofficial" as defined below.
   # For productions pipelines, use "Official".
-  template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     customBuildTags:
     - Ignore-Tag

--- a/azure-pipelines/azure-pipeline.yml
+++ b/azure-pipelines/azure-pipeline.yml
@@ -27,7 +27,7 @@ extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   # For non-production pipelines, use "Unofficial" as defined below.
   # For productions pipelines, use "Official".
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
   parameters:
     customBuildTags:
     - Ignore-Tag

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -18,7 +18,7 @@ variables:
   TeamName: 'Visual Studio Technical Insights'
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
   parameters:
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable


### PR DESCRIPTION
The Publish variant of the 1ES MicroBuild template is required to support publishing artifacts from the official pipelines.