### PR TITLE
Scope PIP_CONFIG_FILE to Build job to fix SDL Sources Analysis timeout

### DIFF
--- a/azure-pipelines/azure-pipeline.yml
+++ b/azure-pipelines/azure-pipeline.yml
@@ -14,8 +14,6 @@ parameters:
 
 variables:
   TeamName: 'Visual Studio Technical Insights'
-  # Route pip through the internal CFS feed; must be set before UsePythonVersion@0 runs its own pip upgrade.
-  PIP_CONFIG_FILE: '$(Build.SourcesDirectory)/pip.ini'
 
 # The `resources` specify the location and version of the 1ES PT.
 resources:
@@ -50,6 +48,12 @@ extends:
               signType: Test
               zipSources: false
         displayName: Build npm package
+        variables:
+          # Route pip through the internal CFS feed; must be set before UsePythonVersion@0 runs its own pip upgrade.
+          # Scoped to this job (not pipeline-wide) so it doesn't leak into the 1ES PT's auto-injected
+          # "SDL Sources Analysis" job, which has no PipAuthenticate step and would hang trying to reach
+          # this private feed until the worker timeout kills it.
+          PIP_CONFIG_FILE: '$(Build.SourcesDirectory)/pip.ini'
 
         steps:
         - task: NodeTool@0


### PR DESCRIPTION
The pipeline-level PIP_CONFIG_FILE variable pointed pip at the private DevDeviceId feed for every job, including the 1ES PT's auto-injected 'SDL Sources Analysis' job used for CodeQL setup. That job has no PipAuthenticate step, so its pip call to the private feed had no credentials and hung silently instead of failing, running until the 2-hour worker timeout killed it (e.g. builds 14642877, 14709629).

Moving PIP_CONFIG_FILE into the Build job's own variables scopes the redirect to the job that actually authenticates against the feed, leaving the SDL job to fall back to public PyPI.